### PR TITLE
feat: ip geolocation on clicks

### DIFF
--- a/internal/services/clicks.go
+++ b/internal/services/clicks.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"log"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -10,20 +11,31 @@ import (
 )
 
 type ClickService struct {
-	db *pgxpool.Pool
+	db  *pgxpool.Pool
+	geo *GeoService
 }
 
-func NewClickService(db *pgxpool.Pool) *ClickService {
-	return &ClickService{db: db}
+func NewClickService(db *pgxpool.Pool, geo *GeoService) *ClickService {
+	return &ClickService{db: db, geo: geo}
 }
 
 func (s *ClickService) Record(ctx context.Context, linkID int, ip, userAgent, referer string) error {
 	device, browser, os := utils.ParseUserAgent(userAgent)
 
+	var country, city string
+	if s.geo != nil {
+		if result, err := s.geo.Lookup(ip); err == nil {
+			country = result.Country
+			city = result.City
+		} else {
+			log.Printf("geo lookup failed for %s: %v", ip, err)
+		}
+	}
+
 	_, err := s.db.Exec(ctx,
-		`INSERT INTO clicks (link_id, ip_address, user_agent, referer, device, browser, os)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-		linkID, ip, userAgent, referer, device, browser, os,
+		`INSERT INTO clicks (link_id, ip_address, user_agent, referer, country, city, device, browser, os)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		linkID, ip, userAgent, referer, country, city, device, browser, os,
 	)
 	return err
 }
@@ -31,15 +43,9 @@ func (s *ClickService) Record(ctx context.Context, linkID int, ip, userAgent, re
 func (s *ClickService) GetStats(ctx context.Context, linkID int, days int) (*models.ClickStats, error) {
 	stats := &models.ClickStats{}
 
-	// total clicks
 	s.db.QueryRow(ctx, "SELECT COUNT(*) FROM clicks WHERE link_id=$1", linkID).Scan(&stats.TotalClicks)
+	s.db.QueryRow(ctx, "SELECT COUNT(DISTINCT ip_address) FROM clicks WHERE link_id=$1", linkID).Scan(&stats.UniqueClicks)
 
-	// unique by ip
-	s.db.QueryRow(ctx,
-		"SELECT COUNT(DISTINCT ip_address) FROM clicks WHERE link_id=$1", linkID,
-	).Scan(&stats.UniqueClicks)
-
-	// clicks by day
 	rows, _ := s.db.Query(ctx,
 		`SELECT DATE(created_at) as day, COUNT(*) FROM clicks
 		 WHERE link_id=$1 AND created_at >= NOW() - INTERVAL '1 day' * $2
@@ -53,7 +59,6 @@ func (s *ClickService) GetStats(ctx context.Context, linkID int, days int) (*mod
 		}
 	}
 
-	// top referrers
 	stats.TopReferrers = s.getTopN(ctx, linkID, "referer", 10)
 	stats.TopCountries = s.getTopN(ctx, linkID, "country", 10)
 	stats.TopBrowsers = s.getTopN(ctx, linkID, "browser", 5)

--- a/internal/services/geo.go
+++ b/internal/services/geo.go
@@ -1,0 +1,58 @@
+package services
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type GeoResult struct {
+	Country string `json:"country"`
+	City    string `json:"city"`
+}
+
+type GeoService struct {
+	client *http.Client
+}
+
+func NewGeoService() *GeoService {
+	return &GeoService{
+		client: &http.Client{Timeout: 2 * time.Second},
+	}
+}
+
+// Lookup returns country and city for an IP address using ip-api.com (free tier).
+func (g *GeoService) Lookup(ip string) (*GeoResult, error) {
+	// strip port if present
+	if host, _, err := net.SplitHostPort(ip); err == nil {
+		ip = host
+	}
+
+	// skip private/local IPs
+	if ip == "" || ip == "127.0.0.1" || ip == "::1" || strings.HasPrefix(ip, "192.168.") || strings.HasPrefix(ip, "10.") {
+		return &GeoResult{Country: "local", City: "local"}, nil
+	}
+
+	resp, err := g.client.Get(fmt.Sprintf("http://ip-api.com/json/%s?fields=country,city,countryCode", ip))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Country     string `json:"country"`
+		City        string `json:"city"`
+		CountryCode string `json:"countryCode"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	return &GeoResult{
+		Country: result.CountryCode,
+		City:    result.City,
+	}, nil
+}


### PR DESCRIPTION
adds geographic data to click tracking:

- GeoService using ip-api.com free tier
- resolves IP to country code + city
- handles private IPs, timeouts (2s max)
- updated ClickService to use geo lookup
- country/city now populated in clicks table

closes #3